### PR TITLE
feat: add --check flag for CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ npx git-detect-case-change --dry
 npx git-detect-case-change --fix-local --dry
 ```
 
+Check mode (exits with code 1 if mismatches are found):
+
+```sh
+npx git-detect-case-change --check
+```
+
 Limit to specific paths:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ npx git-detect-case-change --dry
 npx git-detect-case-change --fix-local --dry
 ```
 
-Check mode (exits with code 1 if mismatches are found):
+Check mode (exits with code 1 if mismatches are found, useful as a lint step or pre-commit hook):
 
 ```sh
 npx git-detect-case-change --check

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,10 +56,14 @@ cli({
 		: await getGitTreeFiles(paths);
 	const caseDifferentFiles = await checkCaseDifferences(gitFiles);
 
-	await applyCaseChanges({
+	const changesFound = await applyCaseChanges({
 		caseDifferentFiles,
 		movedFiles,
 		dry,
 		fixLocal,
 	});
+
+	if (dry && changesFound > 0) {
+		process.exit(1);
+	}
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,11 @@ cli({
 			alias: 'd',
 			description: 'Dry run mode',
 		},
+		check: {
+			type: Boolean,
+			default: false,
+			description: 'Exit with code 1 if case mismatches are found (implies --dry)',
+		},
 		fixLocal: {
 			type: Boolean,
 			default: false,
@@ -38,7 +43,8 @@ cli({
 		description,
 	},
 }, async (argv) => {
-	const { dry, fixLocal, since } = argv.flags;
+	const { fixLocal, since, check } = argv.flags;
+	const dry = argv.flags.dry || check;
 	const { paths } = argv._;
 
 	let sinceRef: string | null = null;
@@ -63,7 +69,7 @@ cli({
 		fixLocal,
 	});
 
-	if (dry && changesFound > 0) {
+	if (check && changesFound > 0) {
 		process.exit(1);
 	}
 });

--- a/src/utils/apply-case-changes.ts
+++ b/src/utils/apply-case-changes.ts
@@ -16,6 +16,8 @@ export const applyCaseChanges = async ({
 	dry,
 	fixLocal,
 }: ApplyOptions) => {
+	let changesFound = 0;
+
 	if (fixLocal) {
 		// In fix-local mode, rename directories first to avoid file-by-file issues
 		const directoryChanges = extractDirectoryChanges(caseDifferentFiles);
@@ -29,6 +31,7 @@ export const applyCaseChanges = async ({
 			}
 
 			console.log(`Fixed: ${localDirectory}/ -> ${gitDirectory}/`);
+			changesFound += 1;
 		}
 	}
 
@@ -77,5 +80,8 @@ export const applyCaseChanges = async ({
 		console.log(fixLocal
 			? `Fixed: ${actualLocalPath.split(path.sep).join('/')} -> ${gitPath}`
 			: `${gitPath} -> ${localPath}`);
+		changesFound += 1;
 	}
+
+	return changesFound;
 };

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -67,12 +67,6 @@ describe('git-detect-case-change', () => {
 
 		expect(result.stdout).toMatch('src/utils.ts -> src/UTILS.ts');
 
-		// Exits with code 1 when changes are detected
-		expect('exitCode' in result).toBe(true);
-		if ('exitCode' in result) {
-			expect(result.exitCode).toBe(1);
-		}
-
 		// Verify nothing was staged
 		const status = await git('status', ['--porcelain']);
 		expect(status).toBe(''); // No changes staged
@@ -245,12 +239,6 @@ describe('--fix-local mode', () => {
 		});
 
 		expect(result.stdout).toMatch('Fixed: src/UTILS.ts -> src/utils.ts');
-
-		// Exits with code 1 when changes are detected
-		expect('exitCode' in result).toBe(true);
-		if ('exitCode' in result) {
-			expect(result.exitCode).toBe(1);
-		}
 
 		// Verify git status still shows the case difference (not fixed in dry mode)
 		const status = await git('status', ['--porcelain']);
@@ -714,5 +702,59 @@ describe('--since mode', () => {
 			expect(result.exitCode).not.toBe(0);
 			expect(result.stderr).toMatch('is not a valid ref');
 		}
+	});
+});
+
+describe('--check mode', () => {
+	test('--check exits with code 1 when mismatches found', async () => {
+		if (isFsCaseSensitive()) {
+			console.log('Skipped: Test only runs on case-insensitive filesystems');
+			return;
+		}
+
+		await using fixture = await createFixture({
+			'src/index.ts': 'export const main = true;',
+		});
+
+		const git = await createGit(fixture.path);
+
+		await git('add', ['src/index.ts']);
+		await git('commit', ['-m', 'Initial commit']);
+
+		await fixture.mv('src/index.ts', 'src/INDEX.ts');
+
+		const result = await gitDetectCaseChange(fixture.path, ['--check']);
+		onTestFail(() => {
+			console.log('Result:', result);
+		});
+
+		expect(result.stdout).toMatch('src/index.ts -> src/INDEX.ts');
+		expect('exitCode' in result).toBe(true);
+		if ('exitCode' in result) {
+			expect(result.exitCode).toBe(1);
+		}
+
+		// Verify nothing was staged (implies --dry)
+		const status = await git('status', ['--porcelain']);
+		expect(status).toBe('');
+	});
+
+	test('--check exits with code 0 when no mismatches', async () => {
+		await using fixture = await createFixture({
+			'src/index.ts': 'export const main = true;',
+		});
+
+		const git = await createGit(fixture.path);
+
+		await git('add', ['src/index.ts']);
+		await git('commit', ['-m', 'Initial commit']);
+
+		const result = await gitDetectCaseChange(fixture.path, ['--check']);
+		onTestFail(() => {
+			console.log('Result:', result);
+		});
+
+		expect(result.stdout).toBe('');
+		expect('exitCode' in result).toBe(false);
 	});
 });

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -67,6 +67,12 @@ describe('git-detect-case-change', () => {
 
 		expect(result.stdout).toMatch('src/utils.ts -> src/UTILS.ts');
 
+		// Exits with code 1 when changes are detected
+		expect('exitCode' in result).toBe(true);
+		if ('exitCode' in result) {
+			expect(result.exitCode).toBe(1);
+		}
+
 		// Verify nothing was staged
 		const status = await git('status', ['--porcelain']);
 		expect(status).toBe(''); // No changes staged
@@ -239,6 +245,12 @@ describe('--fix-local mode', () => {
 		});
 
 		expect(result.stdout).toMatch('Fixed: src/UTILS.ts -> src/utils.ts');
+
+		// Exits with code 1 when changes are detected
+		expect('exitCode' in result).toBe(true);
+		if ('exitCode' in result) {
+			expect(result.exitCode).toBe(1);
+		}
 
 		// Verify git status still shows the case difference (not fixed in dry mode)
 		const status = await git('status', ['--porcelain']);


### PR DESCRIPTION
Add `--check` flag that exits with code 1 when case mismatches are found, without modifying any files (implies `--dry`).

This keeps `--dry` as a pure preview mode while giving CI a dedicated flag to fail on case drift.

Closes #23