### PR TITLE
perf: memoize directory reads in checkCaseDifferences

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,8 +126,9 @@ See [this StackOverflow discussion](https://stackoverflow.com/questions/17683458
 
 2. **Detects case mismatches:**
 
-   For each Git path, uses [`fs.promises.exists`](https://github.com/privatenumber/fs.promises.exists) to look up the actual filesystem path in a case-insensitive way.
-   Files are processed in batches of 100 to avoid file descriptor limits on large repos.
+   Walks each Git path segment-by-segment, looking up directory entries with `fs.readdir`.
+   Reads are memoized by resolved path so each unique parent directory is read at most once, regardless of how many files it contains.
+   Lookups are case-insensitive and Unicode-normalized (NFC) to correctly match files stored in NFD form on macOS/Windows filesystems.
 
 3. **Applies fixes based on mode:**
 

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
 		"nano-spawn": "^2.0.0",
 		"pkgroll": "^2.27.0",
 		"skills-npm": "^1.1.1",
+		"tinyspy": "^4.0.4",
 		"typescript": "^6.0.2"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
 		"clean-pkg-json": "^1.4.1",
 		"cleye": "^2.3.0",
 		"fs-fixture": "^2.13.0",
-		"fs.promises.exists": "^1.1.4",
 		"is-fs-case-sensitive": "^2.0.0",
 		"lintroll": "^1.30.0",
 		"manten": "^2.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       skills-npm:
         specifier: ^1.1.1
         version: 1.1.1
+      tinyspy:
+        specifier: ^4.0.4
+        version: 4.0.4
       typescript:
         specifier: ^6.0.2
         version: 6.0.2
@@ -2615,6 +2618,10 @@ packages:
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+    engines: {node: '>=14.0.0'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -5712,6 +5719,8 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinyspy@4.0.4: {}
 
   to-regex-range@5.0.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,9 +20,6 @@ importers:
       fs-fixture:
         specifier: ^2.13.0
         version: 2.13.0
-      fs.promises.exists:
-        specifier: ^1.1.4
-        version: 1.1.4
       is-fs-case-sensitive:
         specifier: ^2.0.0
         version: 2.0.0
@@ -1640,9 +1637,6 @@ packages:
   fs-fixture@2.13.0:
     resolution: {integrity: sha512-bqL4EVFNgoA38OnztLfeHn4NZJ32zWnSNA3ALtessYO0WjpL//QuYl1YkYd7j+TY0cLO6cqgoHxPJpfSwKQAPA==}
     engines: {node: '>=18.0.0'}
-
-  fs.promises.exists@1.1.4:
-    resolution: {integrity: sha512-lJzUGWbZn8vhGWBedA+RYjB/BeJ+3458ljUfmplqhIeb6ewzTFWNPCR1HCiYCkXV9zxcHz9zXkJzMsEgDLzh3Q==}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -4434,8 +4428,6 @@ snapshots:
   format@0.2.2: {}
 
   fs-fixture@2.13.0: {}
-
-  fs.promises.exists@1.1.4: {}
 
   fsevents@2.3.3:
     optional: true

--- a/src/utils/check-case-differences.ts
+++ b/src/utils/check-case-differences.ts
@@ -14,23 +14,22 @@ const BATCH_SIZE = 100;
 const resolveDirectoryPaths = async (gitFiles: string[], cwd: string) => {
 	// Collect unique directory segments needed at each depth
 	// Key: lowercased dir path, Value: git-cased dir path
-	const uniqueDirs = new Map<string, string>();
-	uniqueDirs.set('.', '.');
+	const uniqueDirectories = new Map<string, string>([['.', '.']]);
 
 	for (const filePath of gitFiles) {
 		const parts = filePath.split('/');
 		for (let i = 1; i < parts.length; i += 1) {
 			const dir = parts.slice(0, i).join('/');
 			const key = dir.toLowerCase();
-			if (!uniqueDirs.has(key)) {
-				uniqueDirs.set(key, dir);
+			if (!uniqueDirectories.has(key)) {
+				uniqueDirectories.set(key, dir);
 			}
 		}
 	}
 
 	// Group directories by depth so we can resolve parents before children
 	const byDepth = new Map<number, string[]>();
-	for (const [key, gitDir] of uniqueDirs) {
+	for (const [key, gitDir] of uniqueDirectories) {
 		if (key === '.') {
 			continue;
 		}
@@ -44,28 +43,26 @@ const resolveDirectoryPaths = async (gitFiles: string[], cwd: string) => {
 	}
 
 	// Map: lowercased dir path -> filesystem-accurate path
-	const resolvedDirs = new Map<string, string>();
-	resolvedDirs.set('.', '.');
+	const resolvedDirectories = new Map<string, string>([['.', '.']]);
 
 	const depthEntries = Array.from(byDepth.entries()).sort(([a], [b]) => a - b);
 
-	for (const [, dirs] of depthEntries) {
-
-		for (let i = 0; i < dirs.length; i += BATCH_SIZE) {
-			const batch = dirs.slice(i, i + BATCH_SIZE);
+	for (const [, directories] of depthEntries) {
+		for (let i = 0; i < directories.length; i += BATCH_SIZE) {
+			const batch = directories.slice(i, i + BATCH_SIZE);
 			await Promise.all(
 				batch.map(async (lowerKey) => {
-					const gitDir = uniqueDirs.get(lowerKey);
+					const gitDir = uniqueDirectories.get(lowerKey);
 					if (!gitDir) {
 						return;
 					}
-					const parts = gitDir.split("/");
+					const parts = gitDir.split('/');
 					const segmentName = parts.at(-1);
 					if (!segmentName) {
 						return;
 					}
-					const parentKey = parts.slice(0, -1).join("/").toLowerCase() || ".";
-					const parentPath = resolvedDirs.get(parentKey);
+					const parentKey = parts.slice(0, -1).join('/').toLowerCase() || '.';
+					const parentPath = resolvedDirectories.get(parentKey);
 
 					if (!parentPath) {
 						// Parent couldn't be resolved, skip
@@ -79,14 +76,14 @@ const resolveDirectoryPaths = async (gitFiles: string[], cwd: string) => {
 						segmentName,
 					);
 					if (resolvedPath) {
-						resolvedDirs.set(lowerKey, resolvedPath);
+						resolvedDirectories.set(lowerKey, resolvedPath);
 					}
 				}),
 			);
 		}
 	}
 
-	return resolvedDirs;
+	return resolvedDirectories;
 };
 
 /**
@@ -102,7 +99,7 @@ const resolveSegment = async (
 	try {
 		const entries = await fs.readdir(absParent);
 		const lowerSegment = segmentName.toLowerCase();
-		const actual = entries.find(e => e.toLowerCase() === lowerSegment);
+		const actual = entries.find(entry => entry.toLowerCase() === lowerSegment);
 		if (actual) {
 			return parentPath === '.' ? actual : `${parentPath}/${actual}`;
 		}
@@ -114,12 +111,12 @@ const resolveSegment = async (
 
 export const checkCaseDifferences = async (gitFiles: string[], cwd = '.') => {
 	// Build a cache of directory entries keyed by resolved filesystem paths
-	const resolvedDirs = await resolveDirectoryPaths(gitFiles, cwd);
+	const resolvedDirectories = await resolveDirectoryPaths(gitFiles, cwd);
 
 	// Read all resolved directories in batches to build a case-insensitive entry cache
 	// Key: lowercased dir path -> Map<lowercased entry name, actual entry name>
 	const dirCache = new Map<string, Map<string, string>>();
-	const dirEntries = [...resolvedDirs.entries()];
+	const dirEntries = [...resolvedDirectories.entries()];
 
 	for (let i = 0; i < dirEntries.length; i += BATCH_SIZE) {
 		const batch = dirEntries.slice(i, i + BATCH_SIZE);

--- a/src/utils/check-case-differences.ts
+++ b/src/utils/check-case-differences.ts
@@ -6,23 +6,35 @@ import path from 'node:path';
 // would miss the match and silently skip the file.
 const canonicalize = (name: string) => name.normalize('NFC').toLowerCase();
 
+type DirectoryIndex = {
+	exact: Set<string>;
+	canonical: Map<string, string>;
+};
+
 export const checkCaseDifferences = async (gitFiles: string[], cwd = '.') => {
-	const directoryCache = new Map<string, Promise<Map<string, string>>>();
+	const directoryCache = new Map<string, Promise<DirectoryIndex>>();
 
 	const readDirectory = (directoryPath: string) => {
 		let cached = directoryCache.get(directoryPath);
 		if (!cached) {
 			cached = fs.readdir(path.join(cwd, directoryPath)).then(
-				(entries) => {
-					const entryMap = new Map<string, string>();
+				(entries): DirectoryIndex => {
+					const exact = new Set(entries);
+					const canonical = new Map<string, string>();
 					for (const entry of entries) {
-						entryMap.set(canonicalize(entry), entry);
+						canonical.set(canonicalize(entry), entry);
 					}
-					return entryMap;
+					return {
+						exact,
+						canonical,
+					};
 				},
-				(error: Error) => {
+				(error: Error): DirectoryIndex => {
 					console.error(`Warning: Could not read directory ${directoryPath}: ${error.message}`);
-					return new Map<string, string>();
+					return {
+						exact: new Set(),
+						canonical: new Map(),
+					};
 				},
 			);
 			directoryCache.set(directoryPath, cached);
@@ -33,8 +45,12 @@ export const checkCaseDifferences = async (gitFiles: string[], cwd = '.') => {
 	const resolveActualPath = async (gitPath: string) => {
 		let actualPath = '.';
 		for (const segment of gitPath.split('/')) {
-			const entries = await readDirectory(actualPath);
-			const actualSegment = entries.get(canonicalize(segment));
+			const { exact, canonical } = await readDirectory(actualPath);
+			// Exact match wins over canonical lookup. On case-sensitive filesystems
+			// a directory may contain both 'index.ts' and 'INDEX.ts' as distinct
+			// files; if git asks for one of them, return that exact entry rather
+			// than whichever case-collision sibling the canonical map happens to hold.
+			const actualSegment = exact.has(segment) ? segment : canonical.get(canonicalize(segment));
 			if (!actualSegment) {
 				return undefined;
 			}

--- a/src/utils/check-case-differences.ts
+++ b/src/utils/check-case-differences.ts
@@ -1,176 +1,59 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 
-const BATCH_SIZE = 100;
-
-/**
- * Resolve filesystem-accurate directory paths by walking the tree segment-by-segment.
- *
- * Git-cased paths can't be passed directly to readdir on case-sensitive filesystems,
- * so we resolve each segment against its parent's actual entries first.
- *
- * Returns a map: lowercased dir path -> filesystem-accurate dir path
- */
-const resolveDirectoryPaths = async (gitFiles: string[], cwd: string) => {
-	// Collect unique directory segments needed at each depth
-	// Key: lowercased dir path, Value: git-cased dir path
-	const uniqueDirectories = new Map<string, string>([['.', '.']]);
-
-	for (const filePath of gitFiles) {
-		const parts = filePath.split('/');
-		for (let i = 1; i < parts.length; i += 1) {
-			const dir = parts.slice(0, i).join('/');
-			const key = dir.toLowerCase();
-			if (!uniqueDirectories.has(key)) {
-				uniqueDirectories.set(key, dir);
-			}
-		}
-	}
-
-	// Group directories by depth so we can resolve parents before children
-	const byDepth = new Map<number, string[]>();
-	for (const [key, gitDir] of uniqueDirectories) {
-		if (key === '.') {
-			continue;
-		}
-		const depth = gitDir.split('/').length;
-		let list = byDepth.get(depth);
-		if (!list) {
-			list = [];
-			byDepth.set(depth, list);
-		}
-		list.push(key);
-	}
-
-	// Map: lowercased dir path -> filesystem-accurate path
-	const resolvedDirectories = new Map<string, string>([['.', '.']]);
-
-	const depthEntries = Array.from(byDepth.entries()).sort(([a], [b]) => a - b);
-
-	for (const [, directories] of depthEntries) {
-		for (let i = 0; i < directories.length; i += BATCH_SIZE) {
-			const batch = directories.slice(i, i + BATCH_SIZE);
-			await Promise.all(
-				batch.map(async (lowerKey) => {
-					const gitDir = uniqueDirectories.get(lowerKey);
-					if (!gitDir) {
-						return;
-					}
-					const parts = gitDir.split('/');
-					const segmentName = parts.at(-1);
-					if (!segmentName) {
-						return;
-					}
-					const parentKey = parts.slice(0, -1).join('/').toLowerCase() || '.';
-					const parentPath = resolvedDirectories.get(parentKey);
-
-					if (!parentPath) {
-						// Parent couldn't be resolved, skip
-						return;
-					}
-
-					// Resolve this segment by reading the parent directory
-					const resolvedPath = await resolveSegment(
-						cwd,
-						parentPath,
-						segmentName,
-					);
-					if (resolvedPath) {
-						resolvedDirectories.set(lowerKey, resolvedPath);
-					}
-				}),
-			);
-		}
-	}
-
-	return resolvedDirectories;
-};
-
-/**
- * Resolve a single path segment against its parent directory on the filesystem.
- * Returns the filesystem-accurate relative path, or undefined if not found.
- */
-const resolveSegment = async (
-	cwd: string,
-	parentPath: string,
-	segmentName: string,
-): Promise<string | undefined> => {
-	const absParent = parentPath === '.' ? cwd : path.join(cwd, parentPath);
-	try {
-		const entries = await fs.readdir(absParent);
-		const lowerSegment = segmentName.toLowerCase();
-		const actual = entries.find(entry => entry.toLowerCase() === lowerSegment);
-		if (actual) {
-			return parentPath === '.' ? actual : `${parentPath}/${actual}`;
-		}
-	} catch (error) {
-		console.error(`Warning: Could not read directory ${parentPath}: ${(error as Error).message}`);
-	}
-	return undefined;
-};
+// NFC-normalized lowercase. Normalization matters on macOS/Windows where a file
+// can be stored NFD on disk while git returns NFC from ls-tree — byte comparison
+// would miss the match and silently skip the file.
+const canonicalize = (name: string) => name.normalize('NFC').toLowerCase();
 
 export const checkCaseDifferences = async (gitFiles: string[], cwd = '.') => {
-	// Build a cache of directory entries keyed by resolved filesystem paths
-	const resolvedDirectories = await resolveDirectoryPaths(gitFiles, cwd);
+	const directoryCache = new Map<string, Promise<Map<string, string>>>();
 
-	// Read all resolved directories in batches to build a case-insensitive entry cache
-	// Key: lowercased dir path -> Map<lowercased entry name, actual entry name>
-	const dirCache = new Map<string, Map<string, string>>();
-	const dirEntries = [...resolvedDirectories.entries()];
-
-	for (let i = 0; i < dirEntries.length; i += BATCH_SIZE) {
-		const batch = dirEntries.slice(i, i + BATCH_SIZE);
-		await Promise.all(
-			batch.map(async ([lowerKey, fsPath]) => {
-				const absFsPath = fsPath === '.' ? cwd : path.join(cwd, fsPath);
-				try {
-					const entries = await fs.readdir(absFsPath);
+	const readDirectory = (directoryPath: string) => {
+		let cached = directoryCache.get(directoryPath);
+		if (!cached) {
+			cached = fs.readdir(path.join(cwd, directoryPath)).then(
+				(entries) => {
 					const entryMap = new Map<string, string>();
 					for (const entry of entries) {
-						entryMap.set(entry.toLowerCase(), entry);
+						entryMap.set(canonicalize(entry), entry);
 					}
-					dirCache.set(lowerKey, entryMap);
-				} catch (error) {
-					console.error(`Warning: Could not read directory ${fsPath}: ${(error as Error).message}`);
-				}
-			}),
-		);
-	}
+					return entryMap;
+				},
+				(error: Error) => {
+					console.error(`Warning: Could not read directory ${directoryPath}: ${error.message}`);
+					return new Map<string, string>();
+				},
+			);
+			directoryCache.set(directoryPath, cached);
+		}
+		return cached;
+	};
 
-	// Resolve actual filesystem paths using the cache (no I/O)
+	const resolveActualPath = async (gitPath: string) => {
+		let actualPath = '.';
+		for (const segment of gitPath.split('/')) {
+			const entries = await readDirectory(actualPath);
+			const actualSegment = entries.get(canonicalize(segment));
+			if (!actualSegment) {
+				return undefined;
+			}
+			actualPath = actualPath === '.' ? actualSegment : `${actualPath}/${actualSegment}`;
+		}
+		return actualPath;
+	};
+
+	const resolved = await Promise.all(
+		gitFiles.map(async gitPath => [gitPath, await resolveActualPath(gitPath)] as const),
+	);
+
 	const result: string[][] = [];
-
-	for (const filePath of gitFiles) {
-		const parts = filePath.split('/');
-		const resolvedParts: string[] = [];
-		let resolved = true;
-
-		for (const part of parts) {
-			const currentDir = resolvedParts.length === 0
-				? '.'
-				: resolvedParts.join('/').toLowerCase();
-			const entries = dirCache.get(currentDir);
-			if (!entries) {
-				resolved = false;
-				break;
-			}
-
-			const actual = entries.get(part.toLowerCase());
-			if (!actual) {
-				resolved = false;
-				break;
-			}
-
-			resolvedParts.push(actual);
-		}
-
-		if (resolved) {
-			const actualPath = resolvedParts.join('/');
-			if (actualPath !== filePath) {
-				result.push([filePath, actualPath]);
-			}
+	for (const [gitPath, actualPath] of resolved) {
+		// Case-preserving normalization compare: a pure NFC/NFD difference isn't
+		// a case change and shouldn't be reported.
+		if (actualPath && actualPath.normalize('NFC') !== gitPath.normalize('NFC')) {
+			result.push([gitPath, actualPath]);
 		}
 	}
-
 	return result;
 };

--- a/src/utils/check-case-differences.ts
+++ b/src/utils/check-case-differences.ts
@@ -47,10 +47,9 @@ const resolveDirectoryPaths = async (gitFiles: string[], cwd: string) => {
 	const resolvedDirs = new Map<string, string>();
 	resolvedDirs.set('.', '.');
 
-	const depths = Array.from(byDepth.keys()).sort((a, b) => a - b);
+	const depthEntries = Array.from(byDepth.entries()).sort(([a], [b]) => a - b);
 
-	for (const depth of depths) {
-		const dirs = byDepth.get(depth)!;
+	for (const [, dirs] of depthEntries) {
 
 		for (let i = 0; i < dirs.length; i += BATCH_SIZE) {
 			const batch = dirs.slice(i, i + BATCH_SIZE);

--- a/src/utils/check-case-differences.ts
+++ b/src/utils/check-case-differences.ts
@@ -1,14 +1,19 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 
-// NFC-normalized lowercase. Normalization matters on macOS/Windows where a file
-// can be stored NFD on disk while git returns NFC from ls-tree — byte comparison
-// would miss the match and silently skip the file.
-const canonicalize = (name: string) => name.normalize('NFC').toLowerCase();
+// Normalization matters on macOS/Windows where a file can be stored NFD on disk
+// while git returns NFC from ls-tree — byte comparison would miss the match.
+const normalize = (name: string) => name.normalize('NFC');
+const canonicalize = (name: string) => normalize(name).toLowerCase();
 
+// Three-tier lookup index per directory. Higher tiers take precedence so that
+// when a directory contains multiple case- or normalization-equivalent siblings,
+// the most-specific match wins instead of whichever entry the lower-tier map
+// happened to hold last.
 type DirectoryIndex = {
-	exact: Set<string>;
-	canonical: Map<string, string>;
+	exact: Set<string>; // bytewise identical
+	normalized: Map<string, string>; // NFC-equal, case preserved
+	canonical: Map<string, string>; // NFC + case-folded
 };
 
 export const checkCaseDifferences = async (gitFiles: string[], cwd = '.') => {
@@ -20,12 +25,15 @@ export const checkCaseDifferences = async (gitFiles: string[], cwd = '.') => {
 			cached = fs.readdir(path.join(cwd, directoryPath)).then(
 				(entries): DirectoryIndex => {
 					const exact = new Set(entries);
+					const normalized = new Map<string, string>();
 					const canonical = new Map<string, string>();
 					for (const entry of entries) {
+						normalized.set(normalize(entry), entry);
 						canonical.set(canonicalize(entry), entry);
 					}
 					return {
 						exact,
+						normalized,
 						canonical,
 					};
 				},
@@ -33,6 +41,7 @@ export const checkCaseDifferences = async (gitFiles: string[], cwd = '.') => {
 					console.error(`Warning: Could not read directory ${directoryPath}: ${error.message}`);
 					return {
 						exact: new Set(),
+						normalized: new Map(),
 						canonical: new Map(),
 					};
 				},
@@ -45,12 +54,11 @@ export const checkCaseDifferences = async (gitFiles: string[], cwd = '.') => {
 	const resolveActualPath = async (gitPath: string) => {
 		let actualPath = '.';
 		for (const segment of gitPath.split('/')) {
-			const { exact, canonical } = await readDirectory(actualPath);
-			// Exact match wins over canonical lookup. On case-sensitive filesystems
-			// a directory may contain both 'index.ts' and 'INDEX.ts' as distinct
-			// files; if git asks for one of them, return that exact entry rather
-			// than whichever case-collision sibling the canonical map happens to hold.
-			const actualSegment = exact.has(segment) ? segment : canonical.get(canonicalize(segment));
+			const { exact, normalized, canonical } = await readDirectory(actualPath);
+			const actualSegment = exact.has(segment)
+				? segment
+				: normalized.get(normalize(segment))
+				?? canonical.get(canonicalize(segment));
 			if (!actualSegment) {
 				return undefined;
 			}
@@ -67,7 +75,7 @@ export const checkCaseDifferences = async (gitFiles: string[], cwd = '.') => {
 	for (const [gitPath, actualPath] of resolved) {
 		// Case-preserving normalization compare: a pure NFC/NFD difference isn't
 		// a case change and shouldn't be reported.
-		if (actualPath && actualPath.normalize('NFC') !== gitPath.normalize('NFC')) {
+		if (actualPath && normalize(actualPath) !== normalize(gitPath)) {
 			result.push([gitPath, actualPath]);
 		}
 	}

--- a/src/utils/check-case-differences.ts
+++ b/src/utils/check-case-differences.ts
@@ -55,10 +55,16 @@ const resolveDirectoryPaths = async (gitFiles: string[], cwd: string) => {
 			const batch = dirs.slice(i, i + BATCH_SIZE);
 			await Promise.all(
 				batch.map(async (lowerKey) => {
-					const gitDir = uniqueDirs.get(lowerKey)!;
-					const parts = gitDir.split('/');
-					const segmentName = parts[parts.length - 1]!;
-					const parentKey = parts.slice(0, -1).join('/').toLowerCase() || '.';
+					const gitDir = uniqueDirs.get(lowerKey);
+					if (!gitDir) {
+						return;
+					}
+					const parts = gitDir.split("/");
+					const segmentName = parts.at(-1);
+					if (!segmentName) {
+						return;
+					}
+					const parentKey = parts.slice(0, -1).join("/").toLowerCase() || ".";
 					const parentPath = resolvedDirs.get(parentKey);
 
 					if (!parentPath) {
@@ -67,7 +73,11 @@ const resolveDirectoryPaths = async (gitFiles: string[], cwd: string) => {
 					}
 
 					// Resolve this segment by reading the parent directory
-					const resolvedPath = await resolveSegment(cwd, parentPath, segmentName);
+					const resolvedPath = await resolveSegment(
+						cwd,
+						parentPath,
+						segmentName,
+					);
 					if (resolvedPath) {
 						resolvedDirs.set(lowerKey, resolvedPath);
 					}

--- a/src/utils/check-case-differences.ts
+++ b/src/utils/check-case-differences.ts
@@ -47,7 +47,7 @@ const resolveDirectoryPaths = async (gitFiles: string[], cwd: string) => {
 	const resolvedDirs = new Map<string, string>();
 	resolvedDirs.set('.', '.');
 
-	const depths = [...byDepth.keys()].sort((a, b) => a - b);
+	const depths = Array.from(byDepth.keys()).sort((a, b) => a - b);
 
 	for (const depth of depths) {
 		const dirs = byDepth.get(depth)!;

--- a/src/utils/check-case-differences.ts
+++ b/src/utils/check-case-differences.ts
@@ -1,32 +1,170 @@
-import exists from 'fs.promises.exists';
+import fs from 'node:fs/promises';
+import path from 'node:path';
 
 const BATCH_SIZE = 100;
 
-export const checkCaseDifferences = async (gitFiles: string[]) => {
-	const result: [string, string | false][] = [];
+/**
+ * Resolve filesystem-accurate directory paths by walking the tree segment-by-segment.
+ *
+ * Git-cased paths can't be passed directly to readdir on case-sensitive filesystems,
+ * so we resolve each segment against its parent's actual entries first.
+ *
+ * Returns a map: lowercased dir path -> filesystem-accurate dir path
+ */
+const resolveDirectoryPaths = async (gitFiles: string[], cwd: string) => {
+	// Collect unique directory segments needed at each depth
+	// Key: lowercased dir path, Value: git-cased dir path
+	const uniqueDirs = new Map<string, string>();
+	uniqueDirs.set('.', '.');
 
-	for (let i = 0; i < gitFiles.length; i += BATCH_SIZE) {
-		const batch = gitFiles.slice(i, i + BATCH_SIZE);
-		const batchResults = await Promise.all(
-			batch.map(async (filePath) => {
+	for (const filePath of gitFiles) {
+		const parts = filePath.split('/');
+		for (let i = 1; i < parts.length; i += 1) {
+			const dir = parts.slice(0, i).join('/');
+			const key = dir.toLowerCase();
+			if (!uniqueDirs.has(key)) {
+				uniqueDirs.set(key, dir);
+			}
+		}
+	}
+
+	// Group directories by depth so we can resolve parents before children
+	const byDepth = new Map<number, string[]>();
+	for (const [key, gitDir] of uniqueDirs) {
+		if (key === '.') {
+			continue;
+		}
+		const depth = gitDir.split('/').length;
+		let list = byDepth.get(depth);
+		if (!list) {
+			list = [];
+			byDepth.set(depth, list);
+		}
+		list.push(key);
+	}
+
+	// Map: lowercased dir path -> filesystem-accurate path
+	const resolvedDirs = new Map<string, string>();
+	resolvedDirs.set('.', '.');
+
+	const depths = [...byDepth.keys()].sort((a, b) => a - b);
+
+	for (const depth of depths) {
+		const dirs = byDepth.get(depth)!;
+
+		for (let i = 0; i < dirs.length; i += BATCH_SIZE) {
+			const batch = dirs.slice(i, i + BATCH_SIZE);
+			await Promise.all(
+				batch.map(async (lowerKey) => {
+					const gitDir = uniqueDirs.get(lowerKey)!;
+					const parts = gitDir.split('/');
+					const segmentName = parts[parts.length - 1]!;
+					const parentKey = parts.slice(0, -1).join('/').toLowerCase() || '.';
+					const parentPath = resolvedDirs.get(parentKey);
+
+					if (!parentPath) {
+						// Parent couldn't be resolved, skip
+						return;
+					}
+
+					// Resolve this segment by reading the parent directory
+					const resolvedPath = await resolveSegment(cwd, parentPath, segmentName);
+					if (resolvedPath) {
+						resolvedDirs.set(lowerKey, resolvedPath);
+					}
+				}),
+			);
+		}
+	}
+
+	return resolvedDirs;
+};
+
+/**
+ * Resolve a single path segment against its parent directory on the filesystem.
+ * Returns the filesystem-accurate relative path, or undefined if not found.
+ */
+const resolveSegment = async (
+	cwd: string,
+	parentPath: string,
+	segmentName: string,
+): Promise<string | undefined> => {
+	const absParent = parentPath === '.' ? cwd : path.join(cwd, parentPath);
+	try {
+		const entries = await fs.readdir(absParent);
+		const lowerSegment = segmentName.toLowerCase();
+		const actual = entries.find(e => e.toLowerCase() === lowerSegment);
+		if (actual) {
+			return parentPath === '.' ? actual : `${parentPath}/${actual}`;
+		}
+	} catch (error) {
+		console.error(`Warning: Could not read directory ${parentPath}: ${(error as Error).message}`);
+	}
+	return undefined;
+};
+
+export const checkCaseDifferences = async (gitFiles: string[], cwd = '.') => {
+	// Build a cache of directory entries keyed by resolved filesystem paths
+	const resolvedDirs = await resolveDirectoryPaths(gitFiles, cwd);
+
+	// Read all resolved directories in batches to build a case-insensitive entry cache
+	// Key: lowercased dir path -> Map<lowercased entry name, actual entry name>
+	const dirCache = new Map<string, Map<string, string>>();
+	const dirEntries = [...resolvedDirs.entries()];
+
+	for (let i = 0; i < dirEntries.length; i += BATCH_SIZE) {
+		const batch = dirEntries.slice(i, i + BATCH_SIZE);
+		await Promise.all(
+			batch.map(async ([lowerKey, fsPath]) => {
+				const absFsPath = fsPath === '.' ? cwd : path.join(cwd, fsPath);
 				try {
-					return [
-						filePath,
-						await exists(filePath, false),
-					] as [string, string | false];
+					const entries = await fs.readdir(absFsPath);
+					const entryMap = new Map<string, string>();
+					for (const entry of entries) {
+						entryMap.set(entry.toLowerCase(), entry);
+					}
+					dirCache.set(lowerKey, entryMap);
 				} catch (error) {
-					// Handle permission errors or other fs errors gracefully
-					console.error(`Warning: Could not check ${filePath}: ${(error as Error).message}`);
-					return [filePath, false] as [string, string | false];
+					console.error(`Warning: Could not read directory ${fsPath}: ${(error as Error).message}`);
 				}
 			}),
 		);
-		result.push(...batchResults);
 	}
 
-	return result.filter(
-		([oldFilePath, newFilePath]) => (
-			newFilePath && (oldFilePath !== newFilePath)
-		),
-	) as string[][];
+	// Resolve actual filesystem paths using the cache (no I/O)
+	const result: string[][] = [];
+
+	for (const filePath of gitFiles) {
+		const parts = filePath.split('/');
+		const resolvedParts: string[] = [];
+		let resolved = true;
+
+		for (const part of parts) {
+			const currentDir = resolvedParts.length === 0
+				? '.'
+				: resolvedParts.join('/').toLowerCase();
+			const entries = dirCache.get(currentDir);
+			if (!entries) {
+				resolved = false;
+				break;
+			}
+
+			const actual = entries.get(part.toLowerCase());
+			if (!actual) {
+				resolved = false;
+				break;
+			}
+
+			resolvedParts.push(actual);
+		}
+
+		if (resolved) {
+			const actualPath = resolvedParts.join('/');
+			if (actualPath !== filePath) {
+				result.push([filePath, actualPath]);
+			}
+		}
+	}
+
+	return result;
 };

--- a/src/utils/check-case-differences.ts
+++ b/src/utils/check-case-differences.ts
@@ -62,7 +62,7 @@ export const checkCaseDifferences = async (gitFiles: string[], cwd = '.') => {
 			if (!actualSegment) {
 				return undefined;
 			}
-			actualPath = actualPath === '.' ? actualSegment : `${actualPath}/${actualSegment}`;
+			actualPath = path.posix.join(actualPath, actualSegment);
 		}
 		return actualPath;
 	};
@@ -74,8 +74,13 @@ export const checkCaseDifferences = async (gitFiles: string[], cwd = '.') => {
 	const result: string[][] = [];
 	for (const [gitPath, actualPath] of resolved) {
 		// Case-preserving normalization compare: a pure NFC/NFD difference isn't
-		// a case change and shouldn't be reported.
-		if (actualPath && normalize(actualPath) !== normalize(gitPath)) {
+		// a case change and shouldn't be reported. Byte-equality short-circuits
+		// the normalize calls in the (overwhelmingly common) no-difference case.
+		if (
+			actualPath
+			&& actualPath !== gitPath
+			&& normalize(actualPath) !== normalize(gitPath)
+		) {
 			result.push([gitPath, actualPath]);
 		}
 	}

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -87,9 +87,9 @@ describe('checkCaseDifferences', () => {
 		expect(file1Change).toBeDefined();
 		expect(file1Change![1]).toBe('src/file1.ts');
 
-		const libChange = result.find(r => r[0] === 'LIB/utils.ts');
-		expect(libChange).toBeDefined();
-		expect(libChange![1]).toBe('lib/utils.ts');
+		const libraryChange = result.find(r => r[0] === 'LIB/utils.ts');
+		expect(libraryChange).toBeDefined();
+		expect(libraryChange![1]).toBe('lib/utils.ts');
 	});
 
 	test('handles file that does not exist on filesystem', async () => {

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs/promises';
+import path from 'node:path';
 import {
 	describe, test, expect, onTestFail,
 } from 'manten';
@@ -174,6 +175,38 @@ describe('checkCaseDifferences', () => {
 		});
 
 		expect(result).toStrictEqual([]);
+	});
+
+	// On case-sensitive filesystems a directory can contain two distinct files that
+	// differ only by case (e.g. 'index.ts' AND 'INDEX.ts'). When git tracks one of
+	// them by its exact name, the resolver must return that exact entry — not the
+	// other case variant that happens to canonicalize to the same key.
+	test('prefers exact segment match over canonical-collision sibling', async () => {
+		await using fixture = await createFixture({
+			'src/index.ts': 'content',
+		});
+		const targetDirectory = path.join(fixture.path, 'src');
+
+		const originalReaddir = fs.readdir;
+		const spy = (async (...args: Parameters<typeof fs.readdir>) => {
+			if (String(args[0]) === targetDirectory) {
+				// Pretend the directory has both case variants.
+				return ['index.ts', 'INDEX.ts'] as never;
+			}
+			return (originalReaddir as (...arguments_: unknown[]) => unknown).apply(fs, args);
+		}) as typeof fs.readdir;
+		fs.readdir = spy;
+
+		try {
+			const result = await checkCaseDifferences(['src/index.ts'], fixture.path);
+			onTestFail(() => {
+				console.log('Result:', result);
+			});
+			// 'src/index.ts' is an exact entry — should not be reported as a difference.
+			expect(result).toStrictEqual([]);
+		} finally {
+			fs.readdir = originalReaddir;
+		}
 	});
 
 	// Normalization handling must not hide genuine case differences that happen to

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -3,9 +3,120 @@ import {
 } from 'manten';
 import { createFixture } from 'fs-fixture';
 import { isFsCaseSensitive } from 'is-fs-case-sensitive';
+import { checkCaseDifferences } from '../src/utils/check-case-differences.ts';
 import { createGit } from './utils/create-git.ts';
 import { gitDetectCaseChange } from './utils/git-detect-case-change.ts';
 import { chmod } from './utils/chmod.ts';
+
+describe('checkCaseDifferences (unit)', () => {
+	test('detects file name case difference', async () => {
+		await using fixture = await createFixture({
+			'src/index.ts': 'content',
+		});
+
+		// Git thinks the file is INDEX.ts, but filesystem has index.ts
+		const result = await checkCaseDifferences(['src/INDEX.ts'], fixture.path);
+		onTestFail(() => {
+			console.log('Result:', result);
+		});
+
+		expect(result.length).toBe(1);
+		expect(result[0]![0]).toBe('src/INDEX.ts');
+		expect(result[0]![1]).toBe('src/index.ts');
+	});
+
+	test('detects directory case difference', async () => {
+		await using fixture = await createFixture({
+			'src/index.ts': 'content',
+		});
+
+		// Git thinks the directory is SRC, but filesystem has src
+		const result = await checkCaseDifferences(['SRC/index.ts'], fixture.path);
+		onTestFail(() => {
+			console.log('Result:', result);
+		});
+
+		expect(result.length).toBe(1);
+		expect(result[0]![0]).toBe('SRC/index.ts');
+		expect(result[0]![1]).toBe('src/index.ts');
+	});
+
+	test('detects nested directory case difference', async () => {
+		await using fixture = await createFixture({
+			'src/components/ui/Button.tsx': 'content',
+		});
+
+		const result = await checkCaseDifferences(['src/COMPONENTS/ui/Button.tsx'], fixture.path);
+		onTestFail(() => {
+			console.log('Result:', result);
+		});
+
+		expect(result.length).toBe(1);
+		expect(result[0]![0]).toBe('src/COMPONENTS/ui/Button.tsx');
+		expect(result[0]![1]).toBe('src/components/ui/Button.tsx');
+	});
+
+	test('returns empty when casing matches', async () => {
+		await using fixture = await createFixture({
+			'src/index.ts': 'content',
+		});
+
+		const result = await checkCaseDifferences(['src/index.ts'], fixture.path);
+		expect(result.length).toBe(0);
+	});
+
+	test('handles multiple files with mixed differences', async () => {
+		await using fixture = await createFixture({
+			'src/file1.ts': 'content1',
+			'src/file2.ts': 'content2',
+			'lib/utils.ts': 'content3',
+		});
+
+		const result = await checkCaseDifferences([
+			'src/FILE1.ts', // case differs
+			'src/file2.ts', // matches
+			'LIB/utils.ts', // directory case differs
+		], fixture.path);
+		onTestFail(() => {
+			console.log('Result:', result);
+		});
+
+		expect(result.length).toBe(2);
+
+		const file1Change = result.find(r => r[0] === 'src/FILE1.ts');
+		expect(file1Change).toBeDefined();
+		expect(file1Change![1]).toBe('src/file1.ts');
+
+		const libChange = result.find(r => r[0] === 'LIB/utils.ts');
+		expect(libChange).toBeDefined();
+		expect(libChange![1]).toBe('lib/utils.ts');
+	});
+
+	test('handles file that does not exist on filesystem', async () => {
+		await using fixture = await createFixture({
+			'src/index.ts': 'content',
+		});
+
+		// Nonexistent file should be silently skipped
+		const result = await checkCaseDifferences(['src/nonexistent.ts'], fixture.path);
+		expect(result.length).toBe(0);
+	});
+
+	test('handles root-level file case difference', async () => {
+		await using fixture = await createFixture({
+			'readme.md': 'content',
+		});
+
+		const result = await checkCaseDifferences(['README.md'], fixture.path);
+		onTestFail(() => {
+			console.log('Result:', result);
+		});
+
+		expect(result.length).toBe(1);
+		expect(result[0]![0]).toBe('README.md');
+		expect(result[0]![1]).toBe('readme.md');
+	});
+});
 
 describe('git-detect-case-change', () => {
 	test('detects basic case change', async () => {

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -8,7 +8,7 @@ import { createGit } from './utils/create-git.ts';
 import { gitDetectCaseChange } from './utils/git-detect-case-change.ts';
 import { chmod } from './utils/chmod.ts';
 
-describe('checkCaseDifferences (unit)', () => {
+describe('checkCaseDifferences', () => {
 	test('detects file name case difference', async () => {
 		await using fixture = await createFixture({
 			'src/index.ts': 'content',

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -11,61 +11,6 @@ import { gitDetectCaseChange } from './utils/git-detect-case-change.ts';
 import { chmod } from './utils/chmod.ts';
 
 describe('checkCaseDifferences', () => {
-	test('reads each directory at most once (perf invariant)', async () => {
-		await using fixture = await createFixture({
-			'src/a/one.ts': '',
-			'src/a/two.ts': '',
-			'src/a/three.ts': '',
-			'src/b/one.ts': '',
-			'src/b/two.ts': '',
-			'lib/x/y/deep.ts': '',
-			'lib/x/y/deeper.ts': '',
-			'lib/x/z/file.ts': '',
-			'readme.md': '',
-		});
-
-		const gitFiles = [
-			'src/a/one.ts',
-			'src/a/two.ts',
-			'src/a/three.ts',
-			'src/b/one.ts',
-			'src/b/two.ts',
-			'lib/x/y/deep.ts',
-			'lib/x/y/deeper.ts',
-			'lib/x/z/file.ts',
-			'readme.md',
-		];
-
-		const readdirCalls: string[] = [];
-		const originalReaddir = fs.readdir;
-		const spy = (async (...args: Parameters<typeof fs.readdir>) => {
-			const callPath = String(args[0]);
-			// Filter to calls targeting our fixture to avoid pollution
-			// from tests running in parallel.
-			if (callPath.startsWith(fixture.path)) {
-				readdirCalls.push(callPath);
-			}
-			return (originalReaddir as (...arguments_: unknown[]) => unknown).apply(fs, args);
-		}) as typeof fs.readdir;
-		fs.readdir = spy;
-
-		try {
-			await checkCaseDifferences(gitFiles, fixture.path);
-		} finally {
-			fs.readdir = originalReaddir;
-		}
-
-		onTestFail(() => {
-			console.log('readdir calls:', readdirCalls);
-		});
-
-		// Unique directories touched: fixture root, src, src/a, src/b, lib, lib/x, lib/x/y, lib/x/z = 8
-		const uniqueDirectoryCount = new Set(readdirCalls).size;
-		expect(uniqueDirectoryCount).toBe(8);
-		// Each unique directory should be read exactly once - the whole point of this module.
-		expect(readdirCalls.length).toBe(uniqueDirectoryCount);
-	});
-
 	test('detects file name case difference', async () => {
 		await using fixture = await createFixture({
 			'src/index.ts': 'content',
@@ -177,6 +122,84 @@ describe('checkCaseDifferences', () => {
 		expect(result).toStrictEqual([]);
 	});
 
+	// Normalization handling must not hide genuine case differences that happen to
+	// coincide with a normalization difference.
+	test('detects case difference even when disk form is NFD', async () => {
+		const nfcLowerName = 'caf\u00E9.ts'; // 'café.ts' composed lowercase
+		const nfdUpperName = 'CAFE\u0301.TS'; // 'CAFÉ.TS' decomposed uppercase
+
+		await using fixture = await createFixture({
+			[nfdUpperName]: 'content',
+		});
+
+		const result = await checkCaseDifferences([nfcLowerName], fixture.path);
+		onTestFail(() => {
+			console.log('Result:', result);
+		});
+
+		expect(result).toStrictEqual([[nfcLowerName, nfdUpperName]]);
+	});
+});
+
+// These tests monkey-patch the global fs.readdir. Manten runs tests within a
+// describe in parallel by default, which would let two spies' install/restore
+// races interleave and corrupt each other. Run them sequentially instead.
+describe('checkCaseDifferences (with fs.readdir spy)', () => {
+	test('reads each directory at most once (perf invariant)', async () => {
+		await using fixture = await createFixture({
+			'src/a/one.ts': '',
+			'src/a/two.ts': '',
+			'src/a/three.ts': '',
+			'src/b/one.ts': '',
+			'src/b/two.ts': '',
+			'lib/x/y/deep.ts': '',
+			'lib/x/y/deeper.ts': '',
+			'lib/x/z/file.ts': '',
+			'readme.md': '',
+		});
+
+		const gitFiles = [
+			'src/a/one.ts',
+			'src/a/two.ts',
+			'src/a/three.ts',
+			'src/b/one.ts',
+			'src/b/two.ts',
+			'lib/x/y/deep.ts',
+			'lib/x/y/deeper.ts',
+			'lib/x/z/file.ts',
+			'readme.md',
+		];
+
+		const readdirCalls: string[] = [];
+		const originalReaddir = fs.readdir;
+		const spy = (async (...args: Parameters<typeof fs.readdir>) => {
+			const callPath = String(args[0]);
+			// Filter to calls targeting our fixture; other tests may also be
+			// hitting fs.readdir during this window.
+			if (callPath.startsWith(fixture.path)) {
+				readdirCalls.push(callPath);
+			}
+			return (originalReaddir as (...arguments_: unknown[]) => unknown).apply(fs, args);
+		}) as typeof fs.readdir;
+		fs.readdir = spy;
+
+		try {
+			await checkCaseDifferences(gitFiles, fixture.path);
+		} finally {
+			fs.readdir = originalReaddir;
+		}
+
+		onTestFail(() => {
+			console.log('readdir calls:', readdirCalls);
+		});
+
+		// Unique directories touched: fixture root, src, src/a, src/b, lib, lib/x, lib/x/y, lib/x/z = 8
+		const uniqueDirectoryCount = new Set(readdirCalls).size;
+		expect(uniqueDirectoryCount).toBe(8);
+		// Each unique directory should be read exactly once - the whole point of this module.
+		expect(readdirCalls.length).toBe(uniqueDirectoryCount);
+	});
+
 	// On case-sensitive filesystems a directory can contain two distinct files that
 	// differ only by case (e.g. 'index.ts' AND 'INDEX.ts'). When git tracks one of
 	// them by its exact name, the resolver must return that exact entry — not the
@@ -209,24 +232,41 @@ describe('checkCaseDifferences', () => {
 		}
 	});
 
-	// Normalization handling must not hide genuine case differences that happen to
-	// coincide with a normalization difference.
-	test('detects case difference even when disk form is NFD', async () => {
-		const nfcLowerName = 'caf\u00E9.ts'; // 'café.ts' composed lowercase
-		const nfdUpperName = 'CAFE\u0301.TS'; // 'CAFÉ.TS' decomposed uppercase
+	// When a directory contains two case-equivalent siblings — one that's only a
+	// normalization difference from the query, and one that's a genuine case
+	// difference — the normalization-equal sibling should win. Otherwise we'd
+	// falsely report the case-different sibling as the "actual" filesystem name.
+	test('prefers normalization-equal sibling over case-different sibling', async () => {
+		const nfcLower = 'caf\u00E9.ts'; // 'café.ts' NFC lowercase (the git path)
+		const nfdLower = 'cafe\u0301.ts'; // 'café.ts' NFD lowercase (semantically equal to nfcLower)
+		const nfcUpper = 'CAF\u00C9.ts'; // 'CAFÉ.ts' NFC uppercase (case-different sibling)
 
 		await using fixture = await createFixture({
-			[nfdUpperName]: 'content',
+			'dir/.gitkeep': '',
 		});
+		const targetDirectory = path.join(fixture.path, 'dir');
 
-		const result = await checkCaseDifferences([nfcLowerName], fixture.path);
-		onTestFail(() => {
-			console.log('Result:', result);
-		});
+		const originalReaddir = fs.readdir;
+		const spy = (async (...args: Parameters<typeof fs.readdir>) => {
+			if (String(args[0]) === targetDirectory) {
+				return [nfdLower, nfcUpper] as never;
+			}
+			return (originalReaddir as (...arguments_: unknown[]) => unknown).apply(fs, args);
+		}) as typeof fs.readdir;
+		fs.readdir = spy;
 
-		expect(result).toStrictEqual([[nfcLowerName, nfdUpperName]]);
+		try {
+			const result = await checkCaseDifferences([`dir/${nfcLower}`], fixture.path);
+			onTestFail(() => {
+				console.log('Result:', result);
+			});
+			// nfdLower is normalization-equal to nfcLower — no case difference to report.
+			expect(result).toStrictEqual([]);
+		} finally {
+			fs.readdir = originalReaddir;
+		}
 	});
-});
+}, { parallel: false });
 
 describe('git-detect-case-change', () => {
 	test('detects basic case change', async () => {

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs/promises';
 import {
 	describe, test, expect, onTestFail,
 } from 'manten';
@@ -9,20 +10,72 @@ import { gitDetectCaseChange } from './utils/git-detect-case-change.ts';
 import { chmod } from './utils/chmod.ts';
 
 describe('checkCaseDifferences', () => {
+	test('reads each directory at most once (perf invariant)', async () => {
+		await using fixture = await createFixture({
+			'src/a/one.ts': '',
+			'src/a/two.ts': '',
+			'src/a/three.ts': '',
+			'src/b/one.ts': '',
+			'src/b/two.ts': '',
+			'lib/x/y/deep.ts': '',
+			'lib/x/y/deeper.ts': '',
+			'lib/x/z/file.ts': '',
+			'readme.md': '',
+		});
+
+		const gitFiles = [
+			'src/a/one.ts',
+			'src/a/two.ts',
+			'src/a/three.ts',
+			'src/b/one.ts',
+			'src/b/two.ts',
+			'lib/x/y/deep.ts',
+			'lib/x/y/deeper.ts',
+			'lib/x/z/file.ts',
+			'readme.md',
+		];
+
+		const readdirCalls: string[] = [];
+		const originalReaddir = fs.readdir;
+		const spy = (async (...args: Parameters<typeof fs.readdir>) => {
+			const callPath = String(args[0]);
+			// Filter to calls targeting our fixture to avoid pollution
+			// from tests running in parallel.
+			if (callPath.startsWith(fixture.path)) {
+				readdirCalls.push(callPath);
+			}
+			return (originalReaddir as (...arguments_: unknown[]) => unknown).apply(fs, args);
+		}) as typeof fs.readdir;
+		fs.readdir = spy;
+
+		try {
+			await checkCaseDifferences(gitFiles, fixture.path);
+		} finally {
+			fs.readdir = originalReaddir;
+		}
+
+		onTestFail(() => {
+			console.log('readdir calls:', readdirCalls);
+		});
+
+		// Unique directories touched: fixture root, src, src/a, src/b, lib, lib/x, lib/x/y, lib/x/z = 8
+		const uniqueDirectoryCount = new Set(readdirCalls).size;
+		expect(uniqueDirectoryCount).toBe(8);
+		// Each unique directory should be read exactly once - the whole point of this module.
+		expect(readdirCalls.length).toBe(uniqueDirectoryCount);
+	});
+
 	test('detects file name case difference', async () => {
 		await using fixture = await createFixture({
 			'src/index.ts': 'content',
 		});
 
-		// Git thinks the file is INDEX.ts, but filesystem has index.ts
 		const result = await checkCaseDifferences(['src/INDEX.ts'], fixture.path);
 		onTestFail(() => {
 			console.log('Result:', result);
 		});
 
-		expect(result.length).toBe(1);
-		expect(result[0]![0]).toBe('src/INDEX.ts');
-		expect(result[0]![1]).toBe('src/index.ts');
+		expect(result).toStrictEqual([['src/INDEX.ts', 'src/index.ts']]);
 	});
 
 	test('detects directory case difference', async () => {
@@ -30,15 +83,12 @@ describe('checkCaseDifferences', () => {
 			'src/index.ts': 'content',
 		});
 
-		// Git thinks the directory is SRC, but filesystem has src
 		const result = await checkCaseDifferences(['SRC/index.ts'], fixture.path);
 		onTestFail(() => {
 			console.log('Result:', result);
 		});
 
-		expect(result.length).toBe(1);
-		expect(result[0]![0]).toBe('SRC/index.ts');
-		expect(result[0]![1]).toBe('src/index.ts');
+		expect(result).toStrictEqual([['SRC/index.ts', 'src/index.ts']]);
 	});
 
 	test('detects nested directory case difference', async () => {
@@ -51,9 +101,7 @@ describe('checkCaseDifferences', () => {
 			console.log('Result:', result);
 		});
 
-		expect(result.length).toBe(1);
-		expect(result[0]![0]).toBe('src/COMPONENTS/ui/Button.tsx');
-		expect(result[0]![1]).toBe('src/components/ui/Button.tsx');
+		expect(result).toStrictEqual([['src/COMPONENTS/ui/Button.tsx', 'src/components/ui/Button.tsx']]);
 	});
 
 	test('returns empty when casing matches', async () => {
@@ -62,7 +110,7 @@ describe('checkCaseDifferences', () => {
 		});
 
 		const result = await checkCaseDifferences(['src/index.ts'], fixture.path);
-		expect(result.length).toBe(0);
+		expect(result).toStrictEqual([]);
 	});
 
 	test('handles multiple files with mixed differences', async () => {
@@ -73,36 +121,30 @@ describe('checkCaseDifferences', () => {
 		});
 
 		const result = await checkCaseDifferences([
-			'src/FILE1.ts', // case differs
-			'src/file2.ts', // matches
-			'LIB/utils.ts', // directory case differs
+			'src/FILE1.ts',
+			'src/file2.ts',
+			'LIB/utils.ts',
 		], fixture.path);
 		onTestFail(() => {
 			console.log('Result:', result);
 		});
 
-		expect(result.length).toBe(2);
-
-		const file1Change = result.find(r => r[0] === 'src/FILE1.ts');
-		expect(file1Change).toBeDefined();
-		expect(file1Change![1]).toBe('src/file1.ts');
-
-		const libraryChange = result.find(r => r[0] === 'LIB/utils.ts');
-		expect(libraryChange).toBeDefined();
-		expect(libraryChange![1]).toBe('lib/utils.ts');
+		expect(result).toStrictEqual([
+			['src/FILE1.ts', 'src/file1.ts'],
+			['LIB/utils.ts', 'lib/utils.ts'],
+		]);
 	});
 
-	test('handles file that does not exist on filesystem', async () => {
+	test('silently skips nonexistent files', async () => {
 		await using fixture = await createFixture({
 			'src/index.ts': 'content',
 		});
 
-		// Nonexistent file should be silently skipped
 		const result = await checkCaseDifferences(['src/nonexistent.ts'], fixture.path);
-		expect(result.length).toBe(0);
+		expect(result).toStrictEqual([]);
 	});
 
-	test('handles root-level file case difference', async () => {
+	test('detects root-level file case difference', async () => {
 		await using fixture = await createFixture({
 			'readme.md': 'content',
 		});
@@ -112,9 +154,44 @@ describe('checkCaseDifferences', () => {
 			console.log('Result:', result);
 		});
 
-		expect(result.length).toBe(1);
-		expect(result[0]![0]).toBe('README.md');
-		expect(result[0]![1]).toBe('readme.md');
+		expect(result).toStrictEqual([['README.md', 'readme.md']]);
+	});
+
+	// On macOS/Windows a file can be stored on disk in NFD (decomposed) form while
+	// git ls-tree returns it in NFC (composed) form — the two byte sequences are
+	// semantically the same file, so nothing should be reported as "different".
+	test('treats NFC git path as equal to NFD disk file', async () => {
+		const nfcName = 'caf\u00E9.ts'; // 'café.ts' composed
+		const nfdName = 'cafe\u0301.ts'; // 'café.ts' decomposed
+
+		await using fixture = await createFixture({
+			[nfdName]: 'content',
+		});
+
+		const result = await checkCaseDifferences([nfcName], fixture.path);
+		onTestFail(() => {
+			console.log('Result:', result);
+		});
+
+		expect(result).toStrictEqual([]);
+	});
+
+	// Normalization handling must not hide genuine case differences that happen to
+	// coincide with a normalization difference.
+	test('detects case difference even when disk form is NFD', async () => {
+		const nfcLowerName = 'caf\u00E9.ts'; // 'café.ts' composed lowercase
+		const nfdUpperName = 'CAFE\u0301.TS'; // 'CAFÉ.TS' decomposed uppercase
+
+		await using fixture = await createFixture({
+			[nfdUpperName]: 'content',
+		});
+
+		const result = await checkCaseDifferences([nfcLowerName], fixture.path);
+		onTestFail(() => {
+			console.log('Result:', result);
+		});
+
+		expect(result).toStrictEqual([[nfcLowerName, nfdUpperName]]);
 	});
 });
 

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -1,10 +1,11 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import {
-	describe, test, expect, onTestFail,
+	describe, test, expect, onTestFail, onTestFinish,
 } from 'manten';
 import { createFixture } from 'fs-fixture';
 import { isFsCaseSensitive } from 'is-fs-case-sensitive';
+import { spyOn } from 'tinyspy';
 import { checkCaseDifferences } from '../src/utils/check-case-differences.ts';
 import { createGit } from './utils/create-git.ts';
 import { gitDetectCaseChange } from './utils/git-detect-case-change.ts';
@@ -141,23 +142,10 @@ describe('checkCaseDifferences', () => {
 	});
 });
 
-// These tests monkey-patch the global fs.readdir. Manten runs tests within a
-// describe in parallel by default, which would let two spies' install/restore
-// races interleave and corrupt each other. Run them sequentially instead.
+// These tests spy on the global fs.readdir. Manten runs tests within a describe
+// in parallel by default, which would let two spies' install/restore races
+// interleave and corrupt each other. Run them sequentially instead.
 describe('checkCaseDifferences (with fs.readdir spy)', () => {
-	const withReaddirStub = async <T>(
-		stub: typeof fs.readdir,
-		run: () => Promise<T>,
-	): Promise<T> => {
-		const original = fs.readdir;
-		fs.readdir = stub;
-		try {
-			return await run();
-		} finally {
-			fs.readdir = original;
-		}
-	};
-
 	test('reads each directory at most once (perf invariant)', async () => {
 		await using fixture = await createFixture({
 			'src/a/one.ts': '',
@@ -183,30 +171,25 @@ describe('checkCaseDifferences (with fs.readdir spy)', () => {
 			'readme.md',
 		];
 
-		const readdirCalls: string[] = [];
-		const originalReaddir = fs.readdir;
-		await withReaddirStub(
-			(async (...args: Parameters<typeof fs.readdir>) => {
-				const callPath = String(args[0]);
-				// Filter to calls targeting our fixture; other tests may also be
-				// hitting fs.readdir during this window.
-				if (callPath.startsWith(fixture.path)) {
-					readdirCalls.push(callPath);
-				}
-				return (originalReaddir as (...arguments_: unknown[]) => unknown).apply(fs, args);
-			}) as typeof fs.readdir,
-			() => checkCaseDifferences(gitFiles, fixture.path),
-		);
+		const spy = spyOn(fs, 'readdir', fs.readdir);
+		onTestFinish(() => spy.restore());
+
+		await checkCaseDifferences(gitFiles, fixture.path);
+
+		// Other tests may also be hitting fs.readdir during this window — filter
+		// to calls targeting our fixture before counting.
+		const fixtureCalls = spy.calls
+			.map(args => String(args[0]))
+			.filter(callPath => callPath.startsWith(fixture.path));
 
 		onTestFail(() => {
-			console.log('readdir calls:', readdirCalls);
+			console.log('fixture readdir calls:', fixtureCalls);
 		});
 
-		// Unique directories touched: fixture root, src, src/a, src/b, lib, lib/x, lib/x/y, lib/x/z = 8
-		const uniqueDirectoryCount = new Set(readdirCalls).size;
-		expect(uniqueDirectoryCount).toBe(8);
-		// Each unique directory should be read exactly once - the whole point of this module.
-		expect(readdirCalls.length).toBe(uniqueDirectoryCount);
+		// Unique directories: fixture root, src, src/a, src/b, lib, lib/x, lib/x/y, lib/x/z = 8.
+		// Each must be read exactly once - the whole point of this module.
+		expect(new Set(fixtureCalls).size).toBe(8);
+		expect(fixtureCalls.length).toBe(8);
 	});
 
 	// On case-sensitive filesystems a directory can contain two distinct files that
@@ -220,17 +203,16 @@ describe('checkCaseDifferences (with fs.readdir spy)', () => {
 		const targetDirectory = path.join(fixture.path, 'src');
 		const originalReaddir = fs.readdir;
 
-		const result = await withReaddirStub(
-			(async (...args: Parameters<typeof fs.readdir>) => {
-				if (String(args[0]) === targetDirectory) {
-					// Pretend the directory has both case variants.
-					return ['index.ts', 'INDEX.ts'] as never;
-				}
-				return (originalReaddir as (...arguments_: unknown[]) => unknown).apply(fs, args);
-			}) as typeof fs.readdir,
-			() => checkCaseDifferences(['src/index.ts'], fixture.path),
-		);
+		const spy = spyOn(fs, 'readdir', (async (...args: Parameters<typeof fs.readdir>) => {
+			if (String(args[0]) === targetDirectory) {
+				// Pretend the directory has both case variants.
+				return ['index.ts', 'INDEX.ts'] as never;
+			}
+			return (originalReaddir as (...arguments_: unknown[]) => unknown).apply(fs, args);
+		}) as typeof fs.readdir);
+		onTestFinish(() => spy.restore());
 
+		const result = await checkCaseDifferences(['src/index.ts'], fixture.path);
 		onTestFail(() => {
 			console.log('Result:', result);
 		});
@@ -253,16 +235,15 @@ describe('checkCaseDifferences (with fs.readdir spy)', () => {
 		const targetDirectory = path.join(fixture.path, 'dir');
 		const originalReaddir = fs.readdir;
 
-		const result = await withReaddirStub(
-			(async (...args: Parameters<typeof fs.readdir>) => {
-				if (String(args[0]) === targetDirectory) {
-					return [nfdLower, nfcUpper] as never;
-				}
-				return (originalReaddir as (...arguments_: unknown[]) => unknown).apply(fs, args);
-			}) as typeof fs.readdir,
-			() => checkCaseDifferences([`dir/${nfcLower}`], fixture.path),
-		);
+		const spy = spyOn(fs, 'readdir', (async (...args: Parameters<typeof fs.readdir>) => {
+			if (String(args[0]) === targetDirectory) {
+				return [nfdLower, nfcUpper] as never;
+			}
+			return (originalReaddir as (...arguments_: unknown[]) => unknown).apply(fs, args);
+		}) as typeof fs.readdir);
+		onTestFinish(() => spy.restore());
 
+		const result = await checkCaseDifferences([`dir/${nfcLower}`], fixture.path);
 		onTestFail(() => {
 			console.log('Result:', result);
 		});

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -145,6 +145,19 @@ describe('checkCaseDifferences', () => {
 // describe in parallel by default, which would let two spies' install/restore
 // races interleave and corrupt each other. Run them sequentially instead.
 describe('checkCaseDifferences (with fs.readdir spy)', () => {
+	const withReaddirStub = async <T>(
+		stub: typeof fs.readdir,
+		run: () => Promise<T>,
+	): Promise<T> => {
+		const original = fs.readdir;
+		fs.readdir = stub;
+		try {
+			return await run();
+		} finally {
+			fs.readdir = original;
+		}
+	};
+
 	test('reads each directory at most once (perf invariant)', async () => {
 		await using fixture = await createFixture({
 			'src/a/one.ts': '',
@@ -172,22 +185,18 @@ describe('checkCaseDifferences (with fs.readdir spy)', () => {
 
 		const readdirCalls: string[] = [];
 		const originalReaddir = fs.readdir;
-		const spy = (async (...args: Parameters<typeof fs.readdir>) => {
-			const callPath = String(args[0]);
-			// Filter to calls targeting our fixture; other tests may also be
-			// hitting fs.readdir during this window.
-			if (callPath.startsWith(fixture.path)) {
-				readdirCalls.push(callPath);
-			}
-			return (originalReaddir as (...arguments_: unknown[]) => unknown).apply(fs, args);
-		}) as typeof fs.readdir;
-		fs.readdir = spy;
-
-		try {
-			await checkCaseDifferences(gitFiles, fixture.path);
-		} finally {
-			fs.readdir = originalReaddir;
-		}
+		await withReaddirStub(
+			(async (...args: Parameters<typeof fs.readdir>) => {
+				const callPath = String(args[0]);
+				// Filter to calls targeting our fixture; other tests may also be
+				// hitting fs.readdir during this window.
+				if (callPath.startsWith(fixture.path)) {
+					readdirCalls.push(callPath);
+				}
+				return (originalReaddir as (...arguments_: unknown[]) => unknown).apply(fs, args);
+			}) as typeof fs.readdir,
+			() => checkCaseDifferences(gitFiles, fixture.path),
+		);
 
 		onTestFail(() => {
 			console.log('readdir calls:', readdirCalls);
@@ -209,27 +218,24 @@ describe('checkCaseDifferences (with fs.readdir spy)', () => {
 			'src/index.ts': 'content',
 		});
 		const targetDirectory = path.join(fixture.path, 'src');
-
 		const originalReaddir = fs.readdir;
-		const spy = (async (...args: Parameters<typeof fs.readdir>) => {
-			if (String(args[0]) === targetDirectory) {
-				// Pretend the directory has both case variants.
-				return ['index.ts', 'INDEX.ts'] as never;
-			}
-			return (originalReaddir as (...arguments_: unknown[]) => unknown).apply(fs, args);
-		}) as typeof fs.readdir;
-		fs.readdir = spy;
 
-		try {
-			const result = await checkCaseDifferences(['src/index.ts'], fixture.path);
-			onTestFail(() => {
-				console.log('Result:', result);
-			});
-			// 'src/index.ts' is an exact entry — should not be reported as a difference.
-			expect(result).toStrictEqual([]);
-		} finally {
-			fs.readdir = originalReaddir;
-		}
+		const result = await withReaddirStub(
+			(async (...args: Parameters<typeof fs.readdir>) => {
+				if (String(args[0]) === targetDirectory) {
+					// Pretend the directory has both case variants.
+					return ['index.ts', 'INDEX.ts'] as never;
+				}
+				return (originalReaddir as (...arguments_: unknown[]) => unknown).apply(fs, args);
+			}) as typeof fs.readdir,
+			() => checkCaseDifferences(['src/index.ts'], fixture.path),
+		);
+
+		onTestFail(() => {
+			console.log('Result:', result);
+		});
+		// 'src/index.ts' is an exact entry — should not be reported as a difference.
+		expect(result).toStrictEqual([]);
 	});
 
 	// When a directory contains two case-equivalent siblings — one that's only a
@@ -245,26 +251,23 @@ describe('checkCaseDifferences (with fs.readdir spy)', () => {
 			'dir/.gitkeep': '',
 		});
 		const targetDirectory = path.join(fixture.path, 'dir');
-
 		const originalReaddir = fs.readdir;
-		const spy = (async (...args: Parameters<typeof fs.readdir>) => {
-			if (String(args[0]) === targetDirectory) {
-				return [nfdLower, nfcUpper] as never;
-			}
-			return (originalReaddir as (...arguments_: unknown[]) => unknown).apply(fs, args);
-		}) as typeof fs.readdir;
-		fs.readdir = spy;
 
-		try {
-			const result = await checkCaseDifferences([`dir/${nfcLower}`], fixture.path);
-			onTestFail(() => {
-				console.log('Result:', result);
-			});
-			// nfdLower is normalization-equal to nfcLower — no case difference to report.
-			expect(result).toStrictEqual([]);
-		} finally {
-			fs.readdir = originalReaddir;
-		}
+		const result = await withReaddirStub(
+			(async (...args: Parameters<typeof fs.readdir>) => {
+				if (String(args[0]) === targetDirectory) {
+					return [nfdLower, nfcUpper] as never;
+				}
+				return (originalReaddir as (...arguments_: unknown[]) => unknown).apply(fs, args);
+			}) as typeof fs.readdir,
+			() => checkCaseDifferences([`dir/${nfcLower}`], fixture.path),
+		);
+
+		onTestFail(() => {
+			console.log('Result:', result);
+		});
+		// nfdLower is normalization-equal to nfcLower — no case difference to report.
+		expect(result).toStrictEqual([]);
 	});
 }, { parallel: false });
 


### PR DESCRIPTION
`checkCaseDifferences` called `fs.promises.exists` per git file, which walks each path segment-by-segment with uncached `readdir`. For N files at depth D that's O(N×D) syscalls — same parents re-read thousands of times. ~60× speedup reported on a ~32k-file codebase.

Replace with a single-pass memoized walker: each unique parent directory is read exactly once regardless of how many files traverse it. Drops the `fs.promises.exists` dependency.

Also fixes two correctness bugs found during review:

- **Unicode normalization:** files stored NFD on disk while git reports NFC (macOS HFS+, rsync-from-Linux) were silently skipped because `.toLowerCase()` compared bytes. Fixed with NFC normalization on both sides.
- **Case-collision false positive:** on case-sensitive filesystems, dirs containing both `index.ts` and `INDEX.ts` could resolve to the wrong sibling. Fixed with a 3-tier lookup (exact → normalized → canonical).

Adds 12 tests (perf-invariant regression + 7 unit + 4 edge-case correctness). Updates README's "How it works" section.